### PR TITLE
[FE] handle outdated comment file references in PR review and add scroll feature in bottom comment viewer

### DIFF
--- a/src/components/File/PRBottomFileExplorer.tsx
+++ b/src/components/File/PRBottomFileExplorer.tsx
@@ -26,7 +26,7 @@ export const PRBottomFileExplorer = () => {
   }, [commentsList]);
 
   return (
-    <div className="overflow-auto p-4">
+    <div className="flex flex-col h-full p-2 overflow-hidden">
       <h3 className="font-medium">
         Commit Information
         <span className="mt-2 pl-2 text-sm text-gray-600 underline">
@@ -34,26 +34,30 @@ export const PRBottomFileExplorer = () => {
           {prInfo.requestUserInfo.branchName}
         </span>
       </h3>
-      {Array.from(fileList).map((file, index) => {
-        const findList = commentsList.filter(
-          (commit) => commit.filename === file,
-        );
-        return (
-          <Accordion
-            key={`file-${index}`}
-            type="single"
-            collapsible
-            className="w-full pt-0"
-          >
-            <AccordionItem value="item-1 border-t" className="border-none">
-              <AccordionTrigger className="py-1">{file}</AccordionTrigger>
-              {findList.map((comment) => (
-                <CommentViewer comments={comment.comments} />
-              ))}
-            </AccordionItem>
-          </Accordion>
-        );
-      })}
+      <div className="flex-1 overflow-y-auto p-2">
+        {Array.from(fileList).map((file, index) => {
+          const findList = commentsList.filter(
+            (commit) => commit.filename === file,
+          );
+          return (
+            <Accordion
+              key={`file-${index}`}
+              type="single"
+              collapsible
+              className="w-full pt-0"
+            >
+              <AccordionItem value="item-1 border-t" className="border-none">
+                <AccordionTrigger className="flex-row-reverse justify-end gap-2 p-0">
+                  {file}
+                </AccordionTrigger>
+                {findList.map((comment) => (
+                  <CommentViewer comments={comment.comments} />
+                ))}
+              </AccordionItem>
+            </Accordion>
+          );
+        })}
+      </div>
     </div>
   );
 };
@@ -69,9 +73,11 @@ const CommentViewer = ({ comments }: CommentViewerProps) => {
   const commitFileList = fileSysyemStore((state) => state.commitFileList);
 
   const navigateCodeEditor = (filePath: string) => {
+    console.log("commitFileList", commitFileList);
     const findSelecetedFile = commitFileList.find(
       (file) => file.filename === filePath,
     )!;
+    console.log("findSelecetedFile", findSelecetedFile);
     if (findSelecetedFile) {
       setSelectedCommitFile(findSelecetedFile);
     } else {
@@ -84,9 +90,9 @@ const CommentViewer = ({ comments }: CommentViewerProps) => {
   const restComments = comments.slice(1);
 
   return (
-    <AccordionContent className="pt-0">
+    <AccordionContent className="py-0">
       <div
-        className="flex items-start gap-3 border-b border-gray-400 p-2"
+        className="flex items-start gap-3 pl-4 pt-2"
         onClick={() => {
           navigateCodeEditor(firstComment.filepath);
         }}
@@ -98,26 +104,31 @@ const CommentViewer = ({ comments }: CommentViewerProps) => {
         />
         <div className="min-w-0 flex-1">
           <div className="flex items-center">
-            <div className="text-sm font-medium">{firstComment.user.login}</div>
-            <div className="pl-2 text-xs text-gray-500">
+            <div className="text-nowrap text-sm font-medium">
+              {firstComment.user.login}
+            </div>
+            <div className="text-nowrap pl-2 text-xs text-gray-500">
               {unixtimeConvertorToKorean(
                 new Date(firstComment.date.created_at),
               )}
             </div>
-          </div>
-          <div className="mt-1 text-sm text-gray-600">
-            {firstComment.body}
-            <span className="pl-1 text-gray-500">
-              [Ln {firstComment.original_line}]
-            </span>
+            <div className="truncate pl-2 text-sm text-gray-600">
+              {firstComment.body}
+              <span className="pl-1 text-gray-500">
+                [Ln {firstComment.original_line}]
+              </span>
+            </div>
           </div>
         </div>
       </div>
       {restComments.length > 0 && (
         <Accordion type="single" collapsible>
-          <AccordionItem value="replies" className="border-none">
-            <AccordionTrigger className="py-2 pl-11 text-sm text-gray-500 hover:no-underline">
-              {restComments.length}개의 답글
+          <AccordionItem value="replies" className="group border-none">
+            <AccordionTrigger className="group flex-row-reverse justify-end gap-2 border-none py-2 pl-11 text-sm text-gray-500">
+              <span className="group-data-[state=open]:hidden">
+                {restComments.length}개의 답글
+              </span>
+              <span className="hidden group-data-[state=open]:block">닫기</span>
             </AccordionTrigger>
             <AccordionContent className="pb-2 pl-11 pt-0">
               {restComments.map((comment, index) => (
@@ -132,20 +143,20 @@ const CommentViewer = ({ comments }: CommentViewerProps) => {
                   />
                   <div className="min-w-0 flex-1">
                     <div className="flex items-center">
-                      <div className="text-sm font-medium">
+                      <div className="text-nowrap text-sm font-medium">
                         {comment.user.login}
                       </div>
-                      <span className="pl-2 text-xs text-gray-500">
+                      <span className="text-nowrap pl-2 text-xs text-gray-500">
                         {unixtimeConvertorToKorean(
                           new Date(comment.date.created_at),
                         )}
                       </span>
-                    </div>
-                    <div className="mt-1 text-sm text-gray-600">
-                      {comment.body}
-                      <span className="text-gray-500">
-                        [Ln {comment.original_line}]
-                      </span>
+                      <div className="truncate pl-2 text-sm text-gray-600">
+                        {comment.body}
+                        <span className="text-gray-500">
+                          [Ln {comment.original_line}]
+                        </span>
+                      </div>
                     </div>
                   </div>
                 </div>

--- a/src/components/File/PRBottomFileExplorer.tsx
+++ b/src/components/File/PRBottomFileExplorer.tsx
@@ -26,7 +26,7 @@ export const PRBottomFileExplorer = () => {
   }, [commentsList]);
 
   return (
-    <div className="flex flex-col h-full p-2 overflow-hidden">
+    <div className="flex h-full flex-col overflow-hidden p-2">
       <h3 className="font-medium">
         Commit Information
         <span className="mt-2 pl-2 text-sm text-gray-600 underline">
@@ -67,27 +67,26 @@ interface CommentViewerProps {
 }
 
 const CommentViewer = ({ comments }: CommentViewerProps) => {
+  const commitFileList = fileSysyemStore((state) => state.commitFileList);
   const setSelectedCommitFile = fileSysyemStore(
     (state) => state.setSelectedCommitFile,
   );
-  const commitFileList = fileSysyemStore((state) => state.commitFileList);
+  const firstComment = comments[0];
+  const restComments = comments.slice(1);
 
   const navigateCodeEditor = (filePath: string) => {
-    console.log("commitFileList", commitFileList);
     const findSelecetedFile = commitFileList.find(
       (file) => file.filename === filePath,
     )!;
-    console.log("findSelecetedFile", findSelecetedFile);
     if (findSelecetedFile) {
       setSelectedCommitFile(findSelecetedFile);
     } else {
-      alert("삭제된 파일의 댓글입니다.");
+      alert(
+        "이 댓글은 파일의 이전 버전에 작성된 내용으로, 현재 파일에서는 열 수 없습니다. 최신 변경 사항과 함께 댓글을 확인해주세요.",
+      );
       return;
     }
   };
-
-  const firstComment = comments[0];
-  const restComments = comments.slice(1);
 
   return (
     <AccordionContent className="py-0">


### PR DESCRIPTION
## 변경사항
- Outdated 상태(삭제, 이름 변경)된 파일에 작성되었던 댓글 클릭 시 발생하는 에러 처리
- 삭제/이동된 파일에 대한 경고 메시지 추가 ("파일이 이동되거나 삭제되었습니다")
- Outdated 상태 댓글 UI 표시 추가
- 댓글창 스크롤 기능

## 문제 상황
PR에서 리뷰 댓글이 달린 파일이 이동/삭제된 경우:
- GitHub API의 `file changed list`에서는 해당 파일이 제외됨
- 하지만 API 응답에는 해당 파일의 댓글들이 여전히 포함됨
- 이로 인해 파일 내용을 보려고 할 때 undefined 에러가 발생

## 해결 방법
- 댓글이 달린 파일을 커밋 파일에서 체크한 후 없다면 사용자에게 알림
```
if (findSelecetedFile) {
  setSelectedCommitFile(findSelecetedFile);
} else {
  alert(
    "이 댓글은 파일의 이전 버전에 작성된 내용으로, 현재 파일에서는 열 수 없습니다. 최신 변경 사항과 함께 댓글을 확인해주세요.",
  );
  return;
}
```

- closes #105 
