### PR TITLE
[FE] feat: add a board to display saved chat and transcribed text from stt

### DIFF
--- a/src/components/Conversation/Save/Chatting.tsx
+++ b/src/components/Conversation/Save/Chatting.tsx
@@ -46,21 +46,21 @@ const ConversationSaveChatViewer = ({
           {chattingData.map((chat, index) => (
             <div
               key={`${chat.date}-${index}`}
-              className={cn([
+              className={cn(
                 "mx-auto mb-4 flex w-full max-w-[90%] sm:max-w-[250px]",
                 chat.status === "voice"
                   ? "translate-x-1/2"
                   : "-translate-x-1/2",
-              ])}
+              )}
             >
               <div className="flex p-3">
                 <div
-                  className={cn([
+                  className={cn(
                     "mr-3 flex h-8 w-8 items-center justify-center rounded-full font-bold",
                     chat.name === chats[0].name
                       ? "bg-gray-300 text-black"
                       : "bg-black text-white",
-                  ])}
+                  )}
                 >
                   {chat.name[0]}
                 </div>

--- a/src/components/Conversation/Save/Chatting.tsx
+++ b/src/components/Conversation/Save/Chatting.tsx
@@ -17,44 +17,54 @@ const ConversationSaveChatViewer = ({
   chats,
   voice,
 }: ConversationSaveChatViewerProps) => {
+  const updateChats = chats.map(chat => ({
+    ...chat,
+    status: "chat"
+  }));
+  
+  const updateVoice = voice.map(voice => ({
+    ...voice,
+    status: "voice"
+  }))
+
+  const chatting = updateChats.concat(updateVoice);
+
+
+  const sortedChatting = [...chatting].sort(function (a, b) {
+    return new Date(a.date).getTime() - new Date(b.date).getTime();
+  })
+  // console.log(sortedChatting);
+  const chattingData = sortedChatting.map(chat => ({
+    ...chat,
+    date: new Date(chat.date).toLocaleString("ko-KR", {timeZone: "Asia/Seoul"})
+  }));
+
   return (
     <div className="flex h-screen">
-      <div className="w-1/2">
-        <div className="h-[calc(100vh-16rem)] w-40 py-2">
-          <div>
-            {chats.map((chat) => {
-              return (
-                <div key={chat.date} className="flex gap-4 py-1">
-                  <div className="flex w-1/12 items-center justify-center rounded border">
-                    {chat.name}
-                  </div>
-                  <div className="w-11/12 rounded border px-4 py-1">
-                    {chat.message}
-                    <div>{chat.date}</div>
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-        </div>
-      </div>
-      <div className="w-1/2">
+      <div className="w-full">
         <div className="h-[calc(100vh-16rem)] py-2">
-          <div>
-            {voice.map((voice) => {
-              return (
-                <div key={voice.date} className="flex gap-4 py-1">
-                  <div className="flex w-1/12 items-center justify-center rounded border">
-                    {voice.name}
-                  </div>
-                  <div className="w-11/12 rounded border px-4 py-1">
-                    {voice.message}
-                    <div>{voice.date}</div>
-                  </div>
+          <ul className="[&:>]:-order-1 bottom-0 flex w-full flex-1 flex-col">
+            {chattingData.map((chat) => (
+              <li
+                key={chat.date}
+                className={`my-1 flex items-end px-2 justify-center ${
+                  chat.status === "voice" ? "ml-auto" : "mr-auto"
+                }`}
+              >
+                <div
+                  className={`max-w-xs rounded-lg p-2 ${
+                    chat.name === chats[0].name
+                      ? "bg-black text-white"
+                      : "bg-gray-300 text-black"
+                  }`}
+                >
+                  <span className="text-xs font-bold">{chat.name}</span>
+                  <p className="text-sm">{chat.message}</p>
+                  <p className="text-xs">{chat.date}</p>
                 </div>
-              );
-            })}
-          </div>
+              </li>
+            ))}
+          </ul>
         </div>
       </div>
     </div>

--- a/src/components/Conversation/Save/Chatting.tsx
+++ b/src/components/Conversation/Save/Chatting.tsx
@@ -1,3 +1,5 @@
+import { cn } from "@/lib/utils";
+
 interface ConversationSaveChatViewerProps {
   chats: {
     date: string;
@@ -22,7 +24,7 @@ const ConversationSaveChatViewer = ({
     ...voice.map((v) => ({ ...v, status: "voice" })),
   ];
 
-  const sortedChatting = [...chatting].sort(function (a, b) {
+  const sortedChatting = [...chatting].sort((a, b) => {
     return new Date(a.date).getTime() - new Date(b.date).getTime();
   });
 
@@ -37,24 +39,28 @@ const ConversationSaveChatViewer = ({
     <div className="flex">
       <div className="w-full">
         <div className="flex w-full items-center justify-center space-x-40">
-          <h1 className="mb-4 text-center text-2xl font-bold">Chatting</h1>
-          <h1 className="mb-4 text-center text-2xl font-bold">Voice Text</h1>
+          <p className="mb-4 text-center text-2xl font-bold">Chatting</p>
+          <p className="mb-4 text-center text-2xl font-bold">Voice Text</p>
         </div>
         <div className="h-[calc(100vh-16rem)] py-2">
-          {chattingData.map((chat) => (
+          {chattingData.map((chat, index) => (
             <div
-              key={chat.date}
-              className={`mx-auto mb-4 flex w-full max-w-[90%] sm:max-w-[250px] ${
-                chat.status === "voice" ? "translate-x-1/2" : "-translate-x-1/2"
-              }`}
+              key={`${chat.date}-${index}`}
+              className={cn([
+                "mx-auto mb-4 flex w-full max-w-[90%] sm:max-w-[250px]",
+                chat.status === "voice"
+                  ? "translate-x-1/2"
+                  : "-translate-x-1/2",
+              ])}
             >
               <div className="flex p-3">
                 <div
-                  className={`mr-3 flex h-8 w-8 items-center justify-center rounded-full font-bold ${
+                  className={cn([
+                    "mr-3 flex h-8 w-8 items-center justify-center rounded-full font-bold",
                     chat.name === chats[0].name
                       ? "bg-gray-300 text-black"
-                      : "bg-black text-white"
-                  }`}
+                      : "bg-black text-white",
+                  ])}
                 >
                   {chat.name[0]}
                 </div>

--- a/src/components/Conversation/Save/Chatting.tsx
+++ b/src/components/Conversation/Save/Chatting.tsx
@@ -18,9 +18,9 @@ const ConversationSaveChatViewer = ({
   voice,
 }: ConversationSaveChatViewerProps) => {
   const chatting = [
-    ...chats.map((c) => ({...c, status: "chat"})),
-    ...voice.map((v) => ({...v, status: "voice"})),
-  ]
+    ...chats.map((c) => ({ ...c, status: "chat" })),
+    ...voice.map((v) => ({ ...v, status: "voice" })),
+  ];
 
   const sortedChatting = [...chatting].sort(function (a, b) {
     return new Date(a.date).getTime() - new Date(b.date).getTime();
@@ -34,33 +34,38 @@ const ConversationSaveChatViewer = ({
   }));
 
   return (
-    <div className="flex h-screen">
+    <div className="flex">
       <div className="w-full">
+        <div className="flex w-full items-center justify-center space-x-40">
+          <h1 className="mb-4 text-center text-2xl font-bold">Chatting</h1>
+          <h1 className="mb-4 text-center text-2xl font-bold">Voice Text</h1>
+        </div>
         <div className="h-[calc(100vh-16rem)] py-2">
-          <ul className="[&:>]:-order-1 bottom-0 flex w-full flex-1 flex-col">
-            {chattingData.map((chat) => (
-              <li
-                key={chat.date}
-                className={`m-auto my-1 w-fit px-2 ${
-                  chat.status === "voice"
-                    ? "translate-x-1/2"
-                    : "-translate-x-1/2"
-                }`}
-              >
+          {chattingData.map((chat) => (
+            <div
+              key={chat.date}
+              className={`mx-auto mb-4 flex w-full max-w-[90%] sm:max-w-[250px] ${
+                chat.status === "voice" ? "translate-x-1/2" : "-translate-x-1/2"
+              }`}
+            >
+              <div className="flex p-3">
                 <div
-                  className={`max-w-xs rounded-lg p-2 ${
+                  className={`mr-3 flex h-8 w-8 items-center justify-center rounded-full font-bold ${
                     chat.name === chats[0].name
-                      ? "bg-black text-white"
-                      : "bg-gray-300 text-black"
+                      ? "bg-gray-300 text-black"
+                      : "bg-black text-white"
                   }`}
                 >
-                  <span className="text-xs font-bold">{chat.name}</span>
-                  <p className="text-sm">{chat.message}</p>
-                  <p className="text-xs">{chat.date}</p>
+                  {chat.name[0]}
                 </div>
-              </li>
-            ))}
-          </ul>
+                <div className="flex-1 text-sm text-gray-700">
+                  <p className="font-semibold text-gray-900">{chat.name}</p>
+                  <p className="truncate">{chat.message}</p>
+                  <p className="truncate text-xs">{chat.date}</p>
+                </div>
+              </div>
+            </div>
+          ))}
         </div>
       </div>
     </div>

--- a/src/components/Conversation/Save/Chatting.tsx
+++ b/src/components/Conversation/Save/Chatting.tsx
@@ -17,26 +17,20 @@ const ConversationSaveChatViewer = ({
   chats,
   voice,
 }: ConversationSaveChatViewerProps) => {
-  const updateChats = chats.map(chat => ({
-    ...chat,
-    status: "chat"
-  }));
-  
-  const updateVoice = voice.map(voice => ({
-    ...voice,
-    status: "voice"
-  }))
-
-  const chatting = updateChats.concat(updateVoice);
-
+  const chatting = [
+    ...chats.map((c) => ({...c, status: "chat"})),
+    ...voice.map((v) => ({...v, status: "voice"})),
+  ]
 
   const sortedChatting = [...chatting].sort(function (a, b) {
     return new Date(a.date).getTime() - new Date(b.date).getTime();
-  })
-  // console.log(sortedChatting);
-  const chattingData = sortedChatting.map(chat => ({
+  });
+
+  const chattingData = sortedChatting.map((chat) => ({
     ...chat,
-    date: new Date(chat.date).toLocaleString("ko-KR", {timeZone: "Asia/Seoul"})
+    date: new Date(chat.date).toLocaleString("ko-KR", {
+      timeZone: "Asia/Seoul",
+    }),
   }));
 
   return (
@@ -47,8 +41,10 @@ const ConversationSaveChatViewer = ({
             {chattingData.map((chat) => (
               <li
                 key={chat.date}
-                className={`my-1 flex items-end px-2 justify-center ${
-                  chat.status === "voice" ? "ml-auto" : "mr-auto"
+                className={`m-auto my-1 w-fit px-2 ${
+                  chat.status === "voice"
+                    ? "translate-x-1/2"
+                    : "-translate-x-1/2"
                 }`}
               >
                 <div

--- a/src/components/Conversation/useConversationChatting.tsx
+++ b/src/components/Conversation/useConversationChatting.tsx
@@ -6,6 +6,7 @@ import { useCommunicationStore } from "@/stores/communicationState.store";
 import { SocketManager } from "@/lib/socketManager";
 import { PreviewChatting } from "@/components/Conversation/PreviewChatting";
 import useChattingScrollEvent from "@/hooks/Conversation/useChattingScrollEvent";
+import { cn } from "@/lib/utils";
 
 export default function ConversationChatting() {
   const [message, setMessage] = useState("");
@@ -81,16 +82,18 @@ export default function ConversationChatting() {
           {messages.map((msg, index) => (
             <li
               key={index}
-              className={`flex items-end px-2 ${
-                msg.name === "나" ? "justify-end" : "justify-start"
-              } my-1`}
+              className={cn([
+                "my-1 flex items-end px-2",
+                msg.name === "나" ? "justify-end" : "justify-start",
+              ])}
             >
               <div
-                className={`max-w-xs rounded-lg p-2 ${
+                className={cn([
+                  "max-w-xs rounded-lg p-2",
                   msg.name === "나"
                     ? "bg-blue-500 text-white"
-                    : "bg-gray-300 text-black"
-                }`}
+                    : "bg-gray-300 text-black",
+                ])}
               >
                 <span className="text-xs font-bold">{msg.name}</span>
                 <p className="text-sm">{msg.message}</p>

--- a/src/components/Conversation/useConversationChatting.tsx
+++ b/src/components/Conversation/useConversationChatting.tsx
@@ -82,18 +82,18 @@ export default function ConversationChatting() {
           {messages.map((msg, index) => (
             <li
               key={index}
-              className={cn([
+              className={cn(
                 "my-1 flex items-end px-2",
                 msg.name === "나" ? "justify-end" : "justify-start",
-              ])}
+              )}
             >
               <div
-                className={cn([
+                className={cn(
                   "max-w-xs rounded-lg p-2",
                   msg.name === "나"
                     ? "bg-blue-500 text-white"
                     : "bg-gray-300 text-black",
-                ])}
+                )}
               >
                 <span className="text-xs font-bold">{msg.name}</span>
                 <p className="text-sm">{msg.message}</p>


### PR DESCRIPTION
## 주요 변경사항
- 저장한 채팅(voice채팅, 일반 채팅)을 저장한 후 이전 회의록에서 보여주기.
## 리뷰어에게...
- 더 원하시는 사항 있으면 추가하겠습니다.
- 코드리뷰를 통해서 코드수정 했습니다! 다른 곳에서도 조건부 className이 있던 부분도 전부 cn으로 수정했습니다.
- 저장된 채팅을 보던 중 map으로 뿌리는 데이터의 key를 시간으로 설정해놔서 동시에 보낸 채팅이 있다면 순서가 꼬이는 문제가 있었는데 key를 date뿐 아니라 index도 추가해서 오류 잡았습니다 감사합니다.
## 관련 이슈

- closes #114 
