### PR TITLE
bug: 채팅메세지 길게 올 시 깨지는 현상해결하기.

### DIFF
--- a/src/components/Conversation/PreviewChatting.tsx
+++ b/src/components/Conversation/PreviewChatting.tsx
@@ -16,14 +16,14 @@ export const PreviewChatting: React.FC<PreviewChattingProps> = ({
     <div className="absolute mx-auto mb-4 flex w-full max-w-[90%] sm:max-w-[250px]">
       <div
         onClick={onClick}
-        className="flex w-full cursor-pointer items-center rounded-md bg-gray-100 p-3 shadow-md transition-colors duration-200 hover:bg-gray-200"
+        className="flex w-full cursor-pointer items-center truncate rounded-md bg-gray-100 p-3 shadow-md transition-colors duration-200 hover:bg-gray-200"
       >
         <div className="mr-3 flex h-8 w-8 items-center justify-center rounded-full bg-gray-300 font-bold text-black">
           {user.name[0]}
         </div>
         <div className="flex-1 text-sm text-gray-700">
           <p className="font-semibold text-gray-900">{user.name}</p>
-          <p className="truncate">{user.message}</p>
+          <p className="text-gray-700">{user.message}</p>
         </div>
       </div>
     </div>

--- a/src/components/Conversation/Save/Chatting.tsx
+++ b/src/components/Conversation/Save/Chatting.tsx
@@ -80,7 +80,7 @@ const ConversationSaveChatViewer = ({
             <div
               key={`${chat.date}-${index}`}
               className={cn(
-                "mx-auto mb-4 flex w-full max-w-[90%] sm:max-w-[250px]",
+                "mx-auto mb-4 flex w-full max-w-[90%] sm:max-w-[300px]",
                 chat.status === "voice"
                   ? "translate-x-1/2"
                   : "-translate-x-1/2",
@@ -99,7 +99,7 @@ const ConversationSaveChatViewer = ({
                 </div>
                 <div className="flex-1 text-sm text-gray-700">
                   <p className="font-semibold text-gray-900">{chat.name}</p>
-                  <p className="truncate">{chat.message}</p>
+                  <p className="break-words">{chat.message}</p>
                   <p className="truncate text-xs">{chat.date}</p>
                 </div>
               </div>

--- a/src/components/Conversation/useConversationChatting.tsx
+++ b/src/components/Conversation/useConversationChatting.tsx
@@ -89,14 +89,14 @@ const ConversationChatting = () => {
             >
               <div
                 className={cn(
-                  "max-w-xs rounded-lg p-2",
+                  "inline-block max-w-[75%] rounded-lg p-2",
                   msg.name === "나"
                     ? "bg-blue-500 text-white"
                     : "bg-gray-300 text-black",
                 )}
               >
                 <span className="text-xs font-bold">{msg.name}</span>
-                <p className="text-sm">{msg.message}</p>
+                <p className="break-words text-sm">{msg.message}</p>
                 <p className="text-xs">{msg.date.toLocaleTimeString()}</p>
               </div>
             </li>


### PR DESCRIPTION
## 주요 변경사항
화상통화 채팅, 채팅 미리보기, 저장된 채팅보기 동일하게 길게 채팅을 받을 시 깨짐현상 발생하여 수정해서 해결함.
## 리뷰어에게...

## 관련 이슈

closes
