### PR TITLE
[FE] fix: Background Transparency in Code Editor View

### DIFF
--- a/src/components/Frame/MainTopFrame.tsx
+++ b/src/components/Frame/MainTopFrame.tsx
@@ -123,7 +123,7 @@ const MainTopFrom = () => {
       >
         <div
           ref={elementRef}
-          className="flex h-full w-full flex-col items-center justify-center"
+          className="flex h-full w-full flex-col items-center justify-center bg-white"
         >
           {selectedCommitFile.filename !== "" && (
             <div className="relative w-full flex-1">


### PR DESCRIPTION
## 주요 변경사항
- 파일 경로 표시 영역과 상단의 열린 파일 리스트가 보드에서 겹치는 문제가 발견되었습니다. 이로 인해 사용자가 열려있는 파일을 선택하거나 파일 경로를 확인할 때 UI가 겹쳐 가독성과 사용성이 떨어지는 상황이 발생합니다.

**해결 사항**  
- 겹침 문제를 해결하기 위해 파일 경로 표시 영역에 배경색을 추가하였습니다.  
- 추가된 배경색은 두 영역이 겹칠 때 시각적으로 구분될 수 있도록 설정되었습니다.

**수정 내역**  
- 경로 표시 영역에 배경색 스타일 적용  
- 상단 열린 파일 리스트와의 간격 조정

**테스트 항목**  
- [x] 여러 파일을 열었을 때 경로 표시 영역과 열린 파일 리스트가 겹치지 않는지 확인  
- [x] 다양한 해상도와 브라우저 환경에서 UI 테스트  

## 관련 이슈

- closes #146 